### PR TITLE
Fix: Correct random line placement in OverlayService

### DIFF
--- a/app/src/main/java/com/example/greenlineprank/services/OverlayService.java
+++ b/app/src/main/java/com/example/greenlineprank/services/OverlayService.java
@@ -39,11 +39,10 @@ public class OverlayService extends Service {
         for (String key : extras.keySet()) {
           Object value = extras.get(key);
           String s = "Extra key: " + key + ", value: " + value;
-          Toast.makeText(getApplicationContext(), s, Toast.LENGTH_SHORT).show();
           Log.d("EXTRAS", s);
         }
       } else {
-        Toast.makeText(getApplicationContext(), "Extra == Null", Toast.LENGTH_SHORT).show();
+        Log.d("EXTRAS", "Extra == Null");
       }
     }
   }
@@ -104,7 +103,6 @@ public class OverlayService extends Service {
     int delayToStart = intent != null ? intent.getIntExtra(Utilities.EXTRA_LINE_DELAY, Utilities.DEFAULT_LINE_DELAY) : Utilities.DEFAULT_LINE_DELAY;
 
 
-    Toast.makeText(getApplicationContext(), "lineLocation ==> " + lineLocation, Toast.LENGTH_SHORT).show();
     int lineLocationOnXAxis = (int) (lineLocation * Utilities.getDisplayLastX(getApplicationContext()));
 
     if (lineNumbers != PrankSettings.RANDOM_LINES) {
@@ -112,11 +110,9 @@ public class OverlayService extends Service {
     } else {
       int randomLines = Utilities.getRandomInt(7);
       int screenWidth = Utilities.getDisplayWidth(getApplicationContext());
-      Toast.makeText(getApplicationContext(), "Width ==> " + screenWidth, Toast.LENGTH_SHORT).show();
 
-      int randomLineLocation = Utilities.getRandomInt(screenWidth);
-      randomLineLocation *= 0.80f;
-      Toast.makeText(getApplicationContext(), "Random lines selected ==> " + randomLines, Toast.LENGTH_SHORT).show();
+      int eightyPercentScreenWidth = (int) (screenWidth * 0.80f);
+      int randomLineLocation = Utilities.getRandomInt(eightyPercentScreenWidth);
       showMultipleOverlays(Utilities.getRandomColors(randomLines), Utilities.getSameWidth(randomLines), Utilities.getRandomLocations(randomLines, randomLineLocation), delayToStart);
     }
     return START_NOT_STICKY;


### PR DESCRIPTION
The previous calculation for `randomLineLocation` when using random lines involved multiplying an integer by a float (0.80f) and then relying on an implicit cast back to int. This could lead to truncation and unexpected line positioning.

This commit refactors the calculation to first determine 80% of the screen width as an integer, and then generate a random number within that range (1 to 80% of screen width). This ensures more accurate and predictable placement of random lines.

Additionally, debug Toast messages were removed from OverlayService.java.